### PR TITLE
Resolve navbar responsiveness issues

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4913,7 +4913,6 @@ select.input-group-sm[multiple]>.input-group-btn>.btn {
   padding-bottom: 10px;
   line-height: 20px;
   vertical-align: middle;
-  margin: 20px 0px 10px 0px;
 }
 
 @media (max-width: 767px) {
@@ -4959,6 +4958,10 @@ select.input-group-sm[multiple]>.input-group-btn>.btn {
 
   .navbar-nav.navbar-right:last-child {
     margin-right: -15px;
+  }
+
+  .navbar-nav>li>a {
+    margin: 20px 0px 10px 0px;
   }
 }
 
@@ -7611,7 +7614,7 @@ button.close {
 }
 
 .navbar .nav>li>a {
-  font-size: 16px;
+  font-size: 11px;
   line-height: 22px;
   font-weight: 400;
   text-transform: uppercase;
@@ -7939,12 +7942,13 @@ section.page {
 }
 
 #google_translate_element {
+  border: 1px solid #000;
   vertical-align: middle;
   background: white;
   padding: 0px 4px;
   border-radius: 0.2em;
   position: fixed;
-  right: 7px;
+  right: 75px;
   top: 7px;
 }
 
@@ -7957,12 +7961,21 @@ section.page {
   .dropdown:hover .dropdown-menu {
     display: block;
   }
+
+  #google_translate_element {
+    right: 7px;
+    top: 100px;
+  }
 }
 
 @media (min-width: 992px) {
   .jumbotron h2 {
     margin-top: 80px;
     max-width: 66%;
+  }
+
+  #google_translate_element {
+    top: 7px;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -20,11 +20,11 @@
     <link rel="manifest" href="assets/favicon_io/site.webmanifest">
     <!-- CSS -->
     <link rel="stylesheet" href="assets/css/main.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   </head>
   <body id ="Site" class='layout-reverse theme-base-sm sidebar-overlay'>
     <!-- Wrap is the content to shift when toggling the sidebar. We wrap the
       content to avoid any CSS collisions with our real content. -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <div class="navbar navbar-expand-sm navbar-default navbar-fixed-top" role="navigation">
       <div class="container" id="nav-container">
         <div class="navbar-header">

--- a/people/index.html
+++ b/people/index.html
@@ -57,8 +57,6 @@
             <br>
             <br>
             <h1>Participants</h1>
-            <br>
-            <br>
           </div>
         </div>
     </section>


### PR DESCRIPTION
Adjusted font size in nav bar to match SIMSSA styling and ensure that header does not block text at smaller breakpoints. Also had to move around Google translate widget at different breakpoints so as not to interfere with menu items.

@maregold here is what it looks like at different breakpoints:

\>992px:
![image](https://github.com/DDMAL/linkedmusic-website/assets/61984039/46d360c1-c9f2-4091-82ee-233fd312bb85)

768-992px:
![image](https://github.com/DDMAL/linkedmusic-website/assets/61984039/9707d179-03a2-40cb-8c4a-c6c3bd4cc181)

<768px (hamburger closed):
![image](https://github.com/DDMAL/linkedmusic-website/assets/61984039/72aebd07-f356-4e22-be75-94783c46dd30)

<768px (hamburger open):
![image](https://github.com/DDMAL/linkedmusic-website/assets/61984039/aa34208d-292e-4da0-a979-fd26d3efec46)

Let me know if you're ok with this. I also added a small black border to make the translate widget more visible on the white background.