### PR TITLE
Unify section titles and standardize content order in workshop pages

### DIFF
--- a/activities/workshops/index.html
+++ b/activities/workshops/index.html
@@ -197,7 +197,7 @@
           
           <h3 id="linkedmusic-workshop-ii">LinkedMusic Workshop III</h3>
           <p>The third LinkedMusic Workshop was held in Munich on 24 July 2023 from 8:30–9:30 am in the Friedrich-von-Gärtner-Saal at the Bavarian State Library (Ludwigstraße 16), as part of the MedRen 2023.</p>
-          <p><a href="/pdfs/fujinaga23LM_WorkshopIII_backup.pdf">PDF's of presentations</a></p>
+          <p><a href="/pdfs/fujinaga23LM_WorkshopIII_backup.pdf">Presentation PDFS</a></p>
           <p><strong>Participants</strong></p>
           <ul>
             <li>Ichiro Fujinaga, McGill University</li>
@@ -224,6 +224,8 @@
 
           <h3 id="linkedmusic-project-meeting">LinkedMusic Project Meeting I</h3>
           <p>We had our first LinkedMusic Project Meeting on 19–20 November 2022, via a hybrid format.</p>
+          <p><a href="/meetings/agenda.html">The agenda from the meeting</a></p>
+          <p><a href="/meetingpdfs">Presentation PDFS</a></p>
           <p><strong>Presenters</strong></p>
           <ul>
             <li>Ichiro Fujinaga, McGill University</li>
@@ -243,10 +245,11 @@
             <li>Jonathan Manton, Yale University</li>
             <li>Anna de Bakker, McGill University</li>
           </ul>
-          <p><a href="/meetings/agenda.html">The agenda from the meeting</a></p>
-          <p><a href="/meetingpdfs">Presentation PDFS</a></p>
+
           <h3 id="linkedmusic-workshop-i-music-databases">LinkedMusic Workshop I (should have been II): Music Databases</h3>
           <p>This workshop, held on November 18th, 2022, was co-organized with CIRMMT Research Axis 2 (Music Information Research).</p>
+          <p><a href="https://www.cirmmt.org/en/events/workshops/research/linkedmusic-workshop">Meeting Agenda</a></p>
+          <p><a href="/meetingpdfs">Presentation PDFS</a></p>
           <p><strong>Presenters</strong></p>
           <ul>
             <li>Simon Dixon, CIRMMT Distinguished Lecturer, Queen Mary, University of London</li>
@@ -264,14 +267,13 @@
             <li>Jacob deGroot-Maggetti, McGill University</li>
             <li>Anna de Bakker, McGill University</li>
           </ul>
-          <p><a href="https://www.cirmmt.org/en/events/workshops/research/linkedmusic-workshop">Meeting Agenda</a></p>
-          <p><a href="/meetingpdfs">Presentation PDFS</a></p>
+
           <h3 id="linkedmusic-workshop-i-music-databases">LinkedMusic Workshop</h3>
           <p>The first LinkedMusic Workshop (hybrid) was held at McGill on October 2nd 2021.</p>
           <p>SSHRC Partnership Grant Stage 2 application</p>
           <p><strong>Participants</strong></p>
           <ul>
-            <li>Ichiro Fujinaga, McGill University</li
+            <li>Ichiro Fujinaga, McGill University</li>
             <li>Jennifer Bain, Dalhousie University</li>
             <li>Debra Lacoste, University of Waterloo</li>
             <li>Julie Cumming, McGill University</li>


### PR DESCRIPTION
- Changed all instances of “PDF's of presentations” to “Presentation PDFS” for consistency.
- Reordered content structure under each workshop: title → intro → agenda → Presentation PDFS.