### PR TITLE
update(workshops): add info for LinkedMusic Workshop VI & VII

### DIFF
--- a/activities/workshops/index.html
+++ b/activities/workshops/index.html
@@ -71,6 +71,62 @@
     <div class="container">
       <div class="row">
         <div class="col-lg-12">
+          <h2 id="2024">2025</h2>
+          <h3>LinkedMusic Workshop VII</h3>
+          <p>The Seventh LinkedMusic Workshop was held on 6 July 2025 in Salzburg, Austria, at the IAML Congress (International
+          Association of Music Libraries, Archives and Documentation Centres). </p>
+           <p><strong>Speaker </strong></p>
+          <ul>
+            <li>Ichiro Fujinaga, McGill University</li>
+          </ul>
+          <p><strong>Participants</strong></p>
+          <ul>
+            <li>Shintaro Seki, Riken, Japan</li>
+            <li>Kevin Kishimoto, Stanford University</li>
+            <li>Jim Cassaro, University of Pittsburgh</li>
+            <li>Kimmy Szeto, City University of New York</li>
+            <li>Federica Riva, Conservatorio di musica Antonio Scontrino, Trapani, Italy</li>
+            <li>Zdravko Blazekovic, RILM, City University of New York</li>
+            <li>Giulia Leccese, Conservatorio di musica Antonio Scontrino, Trapani, Italy</li>
+            <li>Cory McKay, Marianopolis College, Montreal</li>
+            <li>Jihun Jeon, University of Birmingham</li>
+            <li>Jürgen Diet, Bavarian State Library</li>
+            <li>Houman Behzadi, McGill University</li>
+            <li>David Day, Brigham Young University</li>
+            <li>Junjun Cao, McGill University</li>
+          </ul>
+
+          <h3>LinkedMusic Workshop VI</h3>
+          <p>The Sixth LinkedMusic Workshop was held on 1 June 2025 in London, United Kingdom, at the <a href="https://music-encoding.org/conference/2025/"> Music Encoding Conference </a> (St
+          George’s, University of London). </p>
+           <p><strong>Speaker </strong></p>
+          <ul>
+            <li>Ichiro Fujinaga, McGill University</li>
+          </ul>
+          <p><strong>Participants</strong></p>
+          <ul>
+            <li>Antoine Phan, McGill University</li>
+            <li>Joan Cervero Serrano, University of Alicante</li>
+            <li>Cas Rutger Willem Tankink, Utrecht University</li>
+            <li>Huan Zhang, Queen Mary, University of London</li>
+            <li>Laurent Pugin, RISM Digital</li>
+            <li>Tim Eipert, University of Würzburg/li>
+            <li>Rui Yang, University of Lille</li>
+            <li>Elsa De Luca, NOVA University, Lisbon</li>
+            <li>Klaus Rettinghaus, Saxon State and University Library Dresden</li>
+            <li>Simon Dixon, Queen Mary, University of London</li>
+            <li>Sebastian Eck, Oxford University</li>
+            <li>Tim Crawford, Goldsmith University</li>
+            <li>Anna Plaksin, Paderborn University</li>
+            <li>Karen Desmond, Maynooth University</li>
+            <li>Julia Maria Jaklin, TU Wien</li>
+            <li>David Lewis, Oxford University</li>
+            <li>Kevin Page, Oxford University</li>
+            <li>Annabella Schmitz, Akademie der Wissenschaften und der Literatur, Mainz</li>
+            <li>David Weigl, University of Music and Performing Arts Vienna</li>
+            <li>Timothy Duguid, University of Glasgow</li>
+          </ul>
+
           <h2 id="2024">2024</h2>
           <h3>LinkedMusic Project Meeting III</h3>
           <p>The third LinkedMusic Project Meeting was held on 26th October 2024 in Montreal, QC Canada</a> </p>


### PR DESCRIPTION
Added workshop details for:
- LinkedMusic Workshop VI (2025)
- LinkedMusic Workshop VII (2025)

Updated workshop index and detail pages.
